### PR TITLE
Removing require-module luar

### DIFF
--- a/rc/tabs.kak
+++ b/rc/tabs.kak
@@ -1,5 +1,3 @@
-require-module luar
-
 declare-user-mode tabs
 
 declare-option str modelinefmt_tabs %opt{modelinefmt}


### PR DESCRIPTION
It prevents the plugin to be loader if luar isn't there and from my experience this doesn't make the plugin behave differently.